### PR TITLE
Point to adafruit_wm8960 instead of wm8960

### DIFF
--- a/examples/wm8960_simpletest.py
+++ b/examples/wm8960_simpletest.py
@@ -8,11 +8,11 @@
 import audiobusio
 import board
 import synthio
-import wm8960
+import adafruit_wm8960
 import time
 import digitalio
 
-dac = wm8960.WM8960(board.I2C())
+dac = adafruit_wm8960.WM8960(board.I2C())
 dac.start_i2s_out()
 audio = audiobusio.I2SOut(board.AUDIO_BCLK, board.AUDIO_SYNC, board.AUDIO_TXD, main_clock=board.AUDIO_MCLK)
 synth = synthio.Synthesizer(sample_rate=22050)


### PR DESCRIPTION
The example code doesn't work with the library as is. Renaming it to adafruit_wm8960 fixed that.