### PR TITLE
Fix Read the Docs link in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ Usage Example
 
 Documentation
 =============
-API documentation for this library can be found on `Read the Docs <https://docs.circuitpython.org/projects/adafruit_wm8960/en/latest/>`_.
+API documentation for this library can be found on `Read the Docs <https://docs.circuitpython.org/projects/wm8960/en/latest/>`_.
 
 Contributing
 ============


### PR DESCRIPTION
Previous link under the "Documentation" heading had an invalid slug and led to a 404 page.